### PR TITLE
[Bug] Fix the CLI zipping the entire content of the build.

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,10 +31,12 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     - name: Build
       run: msbuild Sonic.sln /t:SonicTheHedgehog /p:Configuration=Debug
+    - name: Copy Artifacts
+      run: mkdir staging && cp .\SonicTheHedgehog\bin\Debug\netstandard2.0\Sonic*.dll staging
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.3
       with:
         # Artifact name
         name: DLLs
-        path: .\SonicTheHedgehog\bin\Debug\netstandard2.0\
+        path: .\staging\
         if-no-files-found: error

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,6 +37,6 @@ jobs:
       uses: actions/upload-artifact@v3.1.3
       with:
         # Artifact name
-        name: DLLs
+        name: DLL
         path: .\staging\
         if-no-files-found: error


### PR DESCRIPTION
Fixes the "Issue" that all DLLs are being zipped and that confuses some users.